### PR TITLE
More options

### DIFF
--- a/src/main/java/org/chegar/IpByteBinBenchmark.java
+++ b/src/main/java/org/chegar/IpByteBinBenchmark.java
@@ -110,8 +110,8 @@ public class IpByteBinBenchmark {
     }
 
     @Benchmark
-    public long ipByteBinConstUnrolled2LongBench() {
-        return ipByteBinConstUnrolled2(qLong, dLong);
+    public long ipByteBinConstUnrolledBQueryLongBench() {
+        return ipByteBinConstUnrolledBQuery(qLong, dLong);
     }
 
     @Benchmark
@@ -289,8 +289,8 @@ public class IpByteBinBenchmark {
         return acc0 + acc1 + acc2 + acc3;
     }
 
-    static long ipByteBinConstUnrolled2(long[] q, long[] d) {
-        long sum0 = 0, sum1 = 0, sum2 = 0, sum3 = 0;
+    static long ipByteBinConstUnrolledBQuery(long[] q, long[] d) {
+        int sum0 = 0, sum1 = 0, sum2 = 0, sum3 = 0;
         for (int i = 0; i < 6; i++) {
             sum0 += Long.bitCount(q[i] & d[i]);
             sum1 += Long.bitCount(q[6 + i] & d[i]);
@@ -411,8 +411,8 @@ public class IpByteBinBenchmark {
         if (ipByteBinPanByteBenchWideCount() != expected) {
             throw new AssertionError("expected:" + expected + " != ipByteBinPanByteBenchWideCount:" + ipByteBinPanByteBenchWideCount());
         }
-        if (ipByteBinConstUnrolled2LongBench() != expected) {
-            throw new AssertionError("expected:" + expected + " != ipByteBinConstUnrolled2LongBench:" + ipByteBinConstUnrolled2LongBench());
+        if (ipByteBinConstUnrolledBQueryLongBench() != expected) {
+            throw new AssertionError("expected:" + expected + " != ipByteBinConstUnrolledBQueryLongBench:" + ipByteBinConstUnrolledBQueryLongBench());
         }
     }
 }

--- a/src/main/java/org/chegar/IpByteBinBenchmark.java
+++ b/src/main/java/org/chegar/IpByteBinBenchmark.java
@@ -110,6 +110,11 @@ public class IpByteBinBenchmark {
     }
 
     @Benchmark
+    public long ipByteBinConstUnrolled2LongBench() {
+        return ipByteBinConstUnrolled2(qLong, dLong);
+    }
+
+    @Benchmark
     public long ipByteBinPanByteBench() {
         return ipByteBinBytePan(qBytes, dBytes);
     }
@@ -284,6 +289,17 @@ public class IpByteBinBenchmark {
         return acc0 + acc1 + acc2 + acc3;
     }
 
+    static long ipByteBinConstUnrolled2(long[] q, long[] d) {
+        long sum0 = 0, sum1 = 0, sum2 = 0, sum3 = 0;
+        for (int i = 0; i < 6; i++) {
+            sum0 += Long.bitCount(q[i] & d[i]);
+            sum1 += Long.bitCount(q[6 + i] & d[i]);
+            sum2 += Long.bitCount(q[2 * 6 + i] & d[i]);
+            sum3 += Long.bitCount(q[3 * 6 + i] & d[i]);
+        }
+        return (sum0) + (sum1 << 1) + (sum2 << 2) + (sum3 << 3);
+    }
+
     static final VectorSpecies<Byte> BYTE_SPECIES = ByteVector.SPECIES_PREFERRED;
 
     public static long ipByteBinBytePan(byte[] q, byte[] d) {
@@ -394,6 +410,9 @@ public class IpByteBinBenchmark {
         }
         if (ipByteBinPanByteBenchWideCount() != expected) {
             throw new AssertionError("expected:" + expected + " != ipByteBinPanByteBenchWideCount:" + ipByteBinPanByteBenchWideCount());
+        }
+        if (ipByteBinConstUnrolled2LongBench() != expected) {
+            throw new AssertionError("expected:" + expected + " != ipByteBinConstUnrolled2LongBench:" + ipByteBinConstUnrolled2LongBench());
         }
     }
 }

--- a/src/main/java/org/chegar/IpByteBinBenchmark.java
+++ b/src/main/java/org/chegar/IpByteBinBenchmark.java
@@ -359,6 +359,12 @@ public class IpByteBinBenchmark {
             vres3 = vres3.lanewise(VectorOperators.BIT_COUNT);
             subRet3 += vres3.reduceLanes(VectorOperators.ADD);
         }
+        for (; r < d.length; r++) {
+            subRet0 += Integer.bitCount((q[r] & d[r]) & 0xFF);
+            subRet1 += Integer.bitCount((q[r + d.length] & d[r]) & 0xFF);
+            subRet2 += Integer.bitCount((q[r + 2 * d.length] & d[r]) & 0xFF);
+            subRet3 += Integer.bitCount((q[r + 3 * d.length] & d[r]) & 0xFF);
+        }
         ret += subRet0;
         ret += subRet1 << 1;
         ret += subRet2 << 2;


### PR DESCRIPTION


On google cloud n2, with adoptium jdk 22.
```
IpByteBinBenchmark.ipByteBinByteBench                          384  thrpt    5  21.271 ± 0.046  ops/us
IpByteBinBenchmark.ipByteBinByteLongBench                      384  thrpt    5  27.506 ± 0.042  ops/us
IpByteBinBenchmark.ipByteBinConstLongBench                     384  thrpt    5  68.318 ± 0.274  ops/us
IpByteBinBenchmark.ipByteBinConstUnrolledBQueryLongBench       384  thrpt    5  83.928 ± 0.260  ops/us
IpByteBinBenchmark.ipByteBinConstUnrolledLongBench             384  thrpt    5  85.534 ± 0.138  ops/us
IpByteBinBenchmark.ipByteBinConstUnrolledUnrolledLongBench     384  thrpt    5  77.893 ± 0.845  ops/us
IpByteBinBenchmark.ipByteBinLongBench                          384  thrpt    5  29.681 ± 0.040  ops/us
IpByteBinBenchmark.ipByteBinLongPan                            384  thrpt    5  34.494 ± 0.062  ops/us
IpByteBinBenchmark.ipByteBinPanByteBench                       384  thrpt    5   6.393 ± 0.011  ops/us
IpByteBinBenchmark.ipByteBinPanByteBenchUnrolled               384  thrpt    5   6.243 ± 0.018  ops/us
IpByteBinBenchmark.ipByteBinPanByteBenchWideCount              384  thrpt    5   4.928 ± 0.016  ops/us
```

On my macbook:
```
IpByteBinBenchmark.ipByteBinByteBench                          384  thrpt    5   13.666 ± 1.474  ops/us
IpByteBinBenchmark.ipByteBinByteLongBench                      384  thrpt    5   18.368 ± 1.400  ops/us
IpByteBinBenchmark.ipByteBinConstLongBench                     384  thrpt    5   18.340 ± 1.038  ops/us
IpByteBinBenchmark.ipByteBinConstUnrolledBQueryLongBench       384  thrpt    5   18.245 ± 1.724  ops/us
IpByteBinBenchmark.ipByteBinConstUnrolledLongBench             384  thrpt    5   18.345 ± 0.559  ops/us
IpByteBinBenchmark.ipByteBinConstUnrolledUnrolledLongBench     384  thrpt    5   18.517 ± 0.405  ops/us
IpByteBinBenchmark.ipByteBinLongBench                          384  thrpt    5   18.563 ± 0.330  ops/us
IpByteBinBenchmark.ipByteBinLongPan                            384  thrpt    5   93.664 ± 6.591  ops/us
IpByteBinBenchmark.ipByteBinPanByteBenchUnrolled               384  thrpt    5  101.871 ± 3.156  ops/us
IpByteBinBenchmark.ipByteBinPanByteBenchWideCount              384  thrpt    5   69.235 ± 2.202  ops/us
```